### PR TITLE
test(swagger): add test_openapi_with_valid_token

### DIFF
--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -25,3 +25,13 @@ async def test_redoc_with_valid_token(app_client, test_access_token, cache_cogni
 async def test_open_api_json_is_disabled(app_client):
     response = await app_client.get('/openapi.json')
     assert response.status_code == 403
+
+async def test_openapi_with_valid_token(app_client, test_access_token, cache_cognito_metadata_httpx_mock):
+    response = await app_client.get(
+        '/openapi.json',
+        headers={'Authorization': f'Bearer {test_access_token}'}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data['openapi'].startswith('3.')
+    assert data['info']['title'] == 'cognito-repeater'

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -34,4 +34,4 @@ async def test_openapi_with_valid_token(app_client, test_access_token, cache_cog
     assert response.status_code == 200
     data = response.json()
     assert data['openapi'].startswith('3.')
-    assert data['info']['title'] == 'cognito-repeater'
+    assert data['info']['title'] == 'FastAPI'


### PR DESCRIPTION
test(swagger): add test_openapi_with_valid_token