### PR TITLE
Feat/license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 vinylhousegarage
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights  
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      
+copies of the Software, and to permit persons to whom the Software is         
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,      
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER        
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.

--- a/app/README.md
+++ b/app/README.md
@@ -29,3 +29,7 @@
 - /docs：Swagger UI 仕様の GUI ドキュメント
 - /redoc：ReDoc 形式 のドキュメント
 - /openapi.json：OpenAPI 仕様の JSON ファイル
+
+## ライセンス
+
+このアプリケーションは [MIT License](https://opensource.org/licenses/MIT) のもとで公開されています。

--- a/app/routers/api_docs.py
+++ b/app/routers/api_docs.py
@@ -25,8 +25,13 @@ async def protected_openapi(request: Request, token: HTTPAuthorizationCredential
     access_token = token.credentials
     await verify_access_token_only(request, access_token)
     app = request.app
-    return JSONResponse(get_openapi(
+    openapi_schema = get_openapi(
         title=app.title,
         version=app.version,
         routes=app.routes,
-    ))
+    )
+    openapi_schema['info']['license'] = {
+        'name': 'MIT License',
+        'url': 'https://opensource.org/licenses/MIT'
+    }
+    return JSONResponse(openapi_schema)

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -35,3 +35,5 @@ async def test_openapi_with_valid_token(app_client, test_access_token, cache_cog
     data = response.json()
     assert data['openapi'].startswith('3.')
     assert data['info']['title'] == 'FastAPI'
+    assert data['info']['license']['name'] == 'MIT License'
+    assert data['info']['license']['url'] == 'https://opensource.org/licenses/MIT'


### PR DESCRIPTION
feat(license): add initial LICENSE
feat(api_docs): include MIT License in OpenAPI schema
test(openapi): assert license field in test_openapi_with_valid_token
docs(readme): add MIT License section to app/README.md
