### PR TITLE
docs(readme,docs): replace '**アプリURL**' with '**APIエンドポイ ント**' in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 ### 5. アクセス情報
   - **GitHubリポジトリURL**
     - [https://github.com/vinylhousegarage/cognito-repeater](https://github.com/vinylhousegarage/cognito-repeater)
-  - **アプリURL**
+  - **APIエンドポイント**
     - [https://cognito-repeater.com](https://cognito-repeater.com)
 
 ### 6. ライセンス

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@
 ### 5. アクセス情報
   - **GitHubリポジトリURL**
     - [https://github.com/vinylhousegarage/cognito-repeater](https://github.com/vinylhousegarage/cognito-repeater)
-  - **アプリURL**
+  - **APIエンドポイント**
     - [https://cognito-repeater.com](https://cognito-repeater.com)
 
 ### 6. ライセンス


### PR DESCRIPTION
docs(readme,docs): replace '**アプリURL**' with '**APIエンドポイント**' in documentation