### PR TITLE
docs(readme,docs): replace 'この API は' with '本 API は' in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@
     - [https://cognito-repeater.com](https://cognito-repeater.com)
 
 ### 6. ライセンス
-  - この API は [MIT License](https://opensource.org/licenses/MIT) のもとで公開されています。
+  - 本 API は [MIT License](https://opensource.org/licenses/MIT) のもとで公開されています。

--- a/app/README.md
+++ b/app/README.md
@@ -59,4 +59,4 @@
     - [https://cognito-repeater.com](https://cognito-repeater.com)
 
 ### 6. ライセンス
-  - この API は [MIT License](https://opensource.org/licenses/MIT) のもとで公開されています。
+  - 本 API は [MIT License](https://opensource.org/licenses/MIT) のもとで公開されています。

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,4 +59,4 @@
     - [https://cognito-repeater.com](https://cognito-repeater.com)
 
 ### 6. ライセンス
-  - この API は [MIT License](https://opensource.org/licenses/MIT) のもとで公開されています。
+  - 本 API は [MIT License](https://opensource.org/licenses/MIT) のもとで公開されています。


### PR DESCRIPTION
docs(readme,docs): replace 'この API は' with '本 API は' in documentation